### PR TITLE
Lap frame save reduction

### DIFF
--- a/F1 Racing Hub/ListenerMethods/Laps/LapsListener.cs
+++ b/F1 Racing Hub/ListenerMethods/Laps/LapsListener.cs
@@ -12,8 +12,9 @@ namespace F1_Racing_Hub
     public partial class RacingHubListener
     {
         private Dictionary<uint,LapDataPacket> lapDataPackets = new Dictionary<uint, LapDataPacket>();
-
         private LapHistory[,] lapHistories = new LapHistory[22, 100];
+
+        private LapFrame[] previousLapFrames = new LapFrame[22];
 
         public void AddLapsMethods()
         {
@@ -56,7 +57,10 @@ namespace F1_Racing_Hub
                         Brake = telemetryPacket.CarTelemetryData[i].Brake,
                         Gear = telemetryPacket.CarTelemetryData[i].Gear
                     };
-                    LapFrameProc.CreateLapFrame(frame);
+                    if (CanSaveLapFrame(frame))
+                    {
+                        LapFrameProc.CreateLapFrame(frame);
+                    }
                 }
                 lapDataPackets.Remove(telemetryPacket.FrameIdentifier);
             }
@@ -75,6 +79,20 @@ namespace F1_Racing_Hub
                 lapHistories[i, lap].SectorTwoTime = historyPacket.LapHistoryData[lap].SectorTwoTime;
                 lapHistories[i, lap].SectorThreeTime = historyPacket.LapHistoryData[lap].SectorThreeTime;
             }
+        }
+
+        private bool CanSaveLapFrame(LapFrame frame)
+        {
+            // 10 metres is an temporary arbitrary distance threshold
+            LapFrame prevFrame = previousLapFrames[frame.CarIndex];
+            if (prevFrame == null ||
+                frame.Distance > prevFrame.Distance + 10f ||
+                frame.LapNumber > prevFrame.LapNumber)
+            {
+                previousLapFrames[frame.CarIndex] = frame;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/lib/F1GameTelemetryLibrary.sln
+++ b/lib/F1GameTelemetryLibrary.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "F1GameTelemetryLibrary", "F
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "F1 Racing Hub", "..\F1 Racing Hub\F1 Racing Hub.csproj", "{DEC7643B-E50F-49B1-8FEF-E291C35968E8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "..\TestApp\TestApp.csproj", "{99E5AD83-9AB7-409B-8924-60BC26D0056F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +21,6 @@ Global
 		{DEC7643B-E50F-49B1-8FEF-E291C35968E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DEC7643B-E50F-49B1-8FEF-E291C35968E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEC7643B-E50F-49B1-8FEF-E291C35968E8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{99E5AD83-9AB7-409B-8924-60BC26D0056F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{99E5AD83-9AB7-409B-8924-60BC26D0056F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{99E5AD83-9AB7-409B-8924-60BC26D0056F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{99E5AD83-9AB7-409B-8924-60BC26D0056F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Temporary measure to prevent saving too many lap frames needlessly.

Lap frames now only save when the car has travelled at least 10 meters since the last lap frame was saved.
Lap frames are also always saved on the first frame after starting a new lap.
Temporary fix for #7