### PR TITLE
Unpacker removes terminator characters from strings

### DIFF
--- a/F1 Racing Hub/Stored Procedures/ParticipantsProc.cs
+++ b/F1 Racing Hub/Stored Procedures/ParticipantsProc.cs
@@ -15,7 +15,7 @@ namespace F1_Racing_Hub.Stored_Procedures
                 ("sessionId", participants.SessionId.ToSql()),
                 ("carIndex", participants.CarIndex),
                 ("aiDriverId", participants.DriverId),
-                ("name", (!participants.Name.Trim('\0').Equals("Player")) ? participants.Name : $"Car #{ participants.RaceNumber }"),
+                ("name", (!participants.Name.Equals("Player")) ? participants.Name : $"Car #{ participants.RaceNumber }"),
                 ("teamId", participants.TeamId),
                 ("nationalityId", participants.Nationality),
                 ("raceNumber", participants.RaceNumber)

--- a/lib/Unpacking/Unpacker.cs
+++ b/lib/Unpacking/Unpacker.cs
@@ -290,7 +290,7 @@
                 {
                     chars[i] = (char)packedData[pointer++];
                 }
-                return new string(chars);
+                return new string(chars).Trim('\0');
             }
             catch (ArgumentException)
             {


### PR DESCRIPTION
Updated the library unpacking class to trim the '\0' characters from the end of strings so that this doesn't need to be done in the app every time.

Also removed now obsolete trim done in participants proc
Fixes #3 